### PR TITLE
Feat: Edit Markdown Content

### DIFF
--- a/app/controllers/document_controller.py
+++ b/app/controllers/document_controller.py
@@ -46,8 +46,8 @@ def save_document():
         new_document = Document(user_id=current_user, created_at=document_data['createdAt'], name=document_data['name'], content=document_data['content'])
         db.session.add(new_document)
         db.session.commit()
-        
-        return jsonify('Document has been saved.'), 201
+
+        return jsonify({'msg': 'Document has been saved.', 'document_id': new_document.id}), 201
     except Exception as e:
         db.session.rollback()
         return jsonify({'error': str(e)}), 500

--- a/app/controllers/document_controller.py
+++ b/app/controllers/document_controller.py
@@ -15,7 +15,7 @@ def get_all_documents():
             'content': document.content
         } for document in documents]
         
-        return jsonify({"documents": documents_data}), 201
+        return jsonify({"documents": documents_data}), 200
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -46,7 +46,24 @@ def save_document():
         new_document = Document(user_id=current_user, created_at=document_data['createdAt'], name=document_data['name'], content=document_data['content'])
         db.session.add(new_document)
         db.session.commit()
+        
         return jsonify('Document has been saved.'), 201
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+    
+@jwt_required()
+def update_document():
+    try:
+        current_user = get_jwt_identity()
+        data = request.get_json()
+        document_data = data['updatedDocumentData']
+        document = db.session.execute(db.select(Document).filter_by(user_id=current_user, id=document_data["id"])).scalar()
+        document.name = document_data["name"]
+        document.content = document_data["content"]
+        db.session.commit()
+
+        return jsonify('Document has been updated.'), 200
     except Exception as e:
         db.session.rollback()
         return jsonify({'error': str(e)}), 500

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -14,3 +14,7 @@ def get_document(document_id):
 @document_bp.route('/api/document/saveDocument', methods=['POST'])
 def save_document():
     return document_controller.save_document()
+
+@document_bp.route('/api/document/updateDocument', methods=["PUT"])
+def update_document():
+    return document_controller.update_document()

--- a/client/src/components/document/Document.jsx
+++ b/client/src/components/document/Document.jsx
@@ -11,8 +11,13 @@ import axios from 'axios';
 
 export default function Document() {
   const { id } = useParams();
-  const { document, setDocument, setAllDocuments, isDocumentUpdated } =
-    useContext(DocumentContext);
+  const {
+    document,
+    setDocument,
+    setAllDocuments,
+    isDocumentUpdated,
+    setIsDocumentUpdated,
+  } = useContext(DocumentContext);
   const { setIsLoggedIn } = useContext(AuthContext);
   const { displaySidebar } = useContext(UIContext);
   const [loadingData, setLoadingData] = useState(false);
@@ -48,6 +53,7 @@ export default function Document() {
 
           setDocument(document);
           setAllDocuments(documents);
+          setIsDocumentUpdated(false);
         } catch (err) {
           console.error(err);
         } finally {

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -45,7 +45,9 @@ export default function Navbar() {
 
     const updatedDocumentData = {
       id: document.id,
-      name: document.name + '.md',
+      name: document.name.includes('.md')
+        ? document.name
+        : document.name + '.md',
       content: document.content,
     };
 

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -43,20 +43,42 @@ export default function Navbar() {
       content: document.content,
     };
 
-    try {
-      const res = await axios.post(
-        '/api/document/saveDocument',
-        { documentData },
-        {
-          withCredentials: true,
-          headers: {
-            'Content-Type': 'application/json',
-            'X-CSRF-TOKEN': getCookie('csrf_access_token'),
-          },
-        }
-      );
+    const updatedDocumentData = {
+      id: document.id,
+      name: document.name,
+      content: document.content,
+    };
 
-      console.log(res);
+    try {
+      if (document.id) {
+        const res = await axios.put(
+          '/api/document/updateDocument',
+          { updatedDocumentData },
+          {
+            withCredentials: true,
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRF-TOKEN': getCookie('csrf_access_token'),
+            },
+          }
+        );
+
+        console.log(res);
+      } else {
+        const res = await axios.post(
+          '/api/document/saveDocument',
+          { documentData },
+          {
+            withCredentials: true,
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRF-TOKEN': getCookie('csrf_access_token'),
+            },
+          }
+        );
+
+        console.log(res);
+      }
       setIsDocumentUpdated(true);
     } catch (err) {
       console.error(err);

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -37,22 +37,16 @@ export default function Navbar() {
     const options = { day: '2-digit', month: 'long', year: 'numeric' };
     const formattedDate = currentDate.toLocaleDateString('en-GB', options);
 
-    const documentData = {
-      createdAt: formattedDate,
-      name: document.name + '.md',
-      content: document.content,
-    };
-
-    const updatedDocumentData = {
-      id: document.id,
-      name: document.name.includes('.md')
-        ? document.name
-        : document.name + '.md',
-      content: document.content,
-    };
-
     try {
       if (document.id) {
+        const updatedDocumentData = {
+          id: document.id,
+          name: document.name.includes('.md')
+            ? document.name
+            : document.name + '.md',
+          content: document.content,
+        };
+
         const res = await axios.put(
           '/api/document/updateDocument',
           { updatedDocumentData },
@@ -67,6 +61,12 @@ export default function Navbar() {
 
         console.log(res);
       } else {
+        const documentData = {
+          createdAt: formattedDate,
+          name: document.name + '.md',
+          content: document.content,
+        };
+
         const res = await axios.post(
           '/api/document/saveDocument',
           { documentData },

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { DocumentContext } from '../../context/DocumentContext';
 import { AuthContext } from '../../context/AuthContext';
 import { UIContext } from '../../context/UIContext';
@@ -16,6 +17,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default function Navbar() {
+  const navigate = useNavigate();
   const { document, setDocument, setIsDocumentUpdated } =
     useContext(DocumentContext);
   const { isLoggedIn } = useContext(AuthContext);
@@ -79,7 +81,8 @@ export default function Navbar() {
           }
         );
 
-        console.log(res);
+        const documentId = res.data.document_id;
+        navigate(`/document/${documentId}`);
       }
       setIsDocumentUpdated(true);
     } catch (err) {

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -25,7 +25,7 @@ export default function Navbar() {
     setDocument(prevState => {
       return {
         ...prevState,
-        name: e.target.value + '.md',
+        name: e.target.value,
       };
     });
   }
@@ -39,13 +39,13 @@ export default function Navbar() {
 
     const documentData = {
       createdAt: formattedDate,
-      name: document.name,
+      name: document.name + '.md',
       content: document.content,
     };
 
     const updatedDocumentData = {
       id: document.id,
-      name: document.name,
+      name: document.name + '.md',
       content: document.content,
     };
 
@@ -100,6 +100,7 @@ export default function Navbar() {
               name="name"
               id="name"
               placeholder="welcome.md"
+              value={document.name ? document.name : ''}
               onChange={handleInputChange}
             />
           </div>


### PR DESCRIPTION
## Description
This PR allows users to edit their markdown documents. I updated the existing `handleSaveDocument` function to handle both document creation and updating. I added a check to see if the current document has an existing `id` property. If it does, the function makes a PUT request to `'/document/updateDocument'` endpoint sending the `updatedDoucmentData` object which contains just the name and content to be updated. On the server, I created the `'/document/updateDocument'` endpoint, which the server then queries the database for the document based on the user id and the document id. Then to update the document's name and content, I modify the corresponding attributes on the model object with the provided data.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |