### PR TITLE
Feat: Enable Document Deletion

### DIFF
--- a/app/controllers/document_controller.py
+++ b/app/controllers/document_controller.py
@@ -67,3 +67,17 @@ def update_document():
     except Exception as e:
         db.session.rollback()
         return jsonify({'error': str(e)}), 500
+    
+@jwt_required()
+def delete_document(document_id):
+    try:
+        current_user = get_jwt_identity()
+        document = db.session.execute(db.select(Document).filter_by(user_id=current_user, id=document_id)).scalar()
+        db.session.delete(document)
+        db.session.commit()
+
+        return jsonify('Document has been deleted.'), 204
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'error': str(e)}), 500
+    

--- a/app/routes/document_routes.py
+++ b/app/routes/document_routes.py
@@ -18,3 +18,7 @@ def save_document():
 @document_bp.route('/api/document/updateDocument', methods=["PUT"])
 def update_document():
     return document_controller.update_document()
+
+@document_bp.route('/api/document/deleteDocument/<int:document_id>', methods=["DELETE"])
+def delete_document(document_id):
+    return document_controller.delete_document(document_id)

--- a/client/src/components/document/Delete.jsx
+++ b/client/src/components/document/Delete.jsx
@@ -3,10 +3,13 @@ import { DocumentContext } from '../../context/DocumentContext';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { getCookie } from '../../utils/cookies';
+import { defaultMarkdown } from '../../defaultMarkdown';
 
 export default function Delete() {
-  const { document } = useContext(DocumentContext);
+  const { document, allDocuments, setDocument } = useContext(DocumentContext);
   const navigate = useNavigate();
+
+  const documentIndex = allDocuments.findIndex(doc => doc.id === document.id);
 
   async function handleDeleteDocument() {
     try {
@@ -21,6 +24,15 @@ export default function Delete() {
         }
       );
       console.log(res);
+
+      if (allDocuments.length === 1) {
+        setDocument(defaultMarkdown);
+        navigate('/document');
+      } else if (documentIndex === 0) {
+        navigate(`/document/${allDocuments[1].id}`);
+      } else {
+        navigate(`/document/${allDocuments[documentIndex - 1].id}`);
+      }
     } catch (err) {
       console.error(err);
     }

--- a/client/src/components/document/Delete.jsx
+++ b/client/src/components/document/Delete.jsx
@@ -1,9 +1,30 @@
 import { useContext } from 'react';
 import { DocumentContext } from '../../context/DocumentContext';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { getCookie } from '../../utils/cookies';
 
 export default function Delete() {
   const { document } = useContext(DocumentContext);
+  const navigate = useNavigate();
 
+  async function handleDeleteDocument() {
+    try {
+      const res = await axios.delete(
+        `/api/document/deleteDocument/${document.id}`,
+        {
+          withCredentials: true,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': getCookie('csrf_access_token'),
+          },
+        }
+      );
+      console.log(res);
+    } catch (err) {
+      console.error(err);
+    }
+  }
   return (
     <div>
       <h2>Delete this document?</h2>
@@ -11,7 +32,7 @@ export default function Delete() {
         Are you sure you want to delete the {`'${document.name}'`} document and
         its contents? This action cannot be reversed.
       </p>
-      <button>Confirm & Delete</button>
+      <button onClick={handleDeleteDocument}>Confirm & Delete</button>
     </div>
   );
 }

--- a/client/src/components/document/Delete.jsx
+++ b/client/src/components/document/Delete.jsx
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { DocumentContext } from '../../context/DocumentContext';
+
+export default function Delete() {
+  const { document } = useContext(DocumentContext);
+
+  return (
+    <div>
+      <h2>Delete this document?</h2>
+      <p>
+        Are you sure you want to delete the {`'${document.name}'`} document and
+        its contents? This action cannot be reversed.
+      </p>
+      <button>Confirm & Delete</button>
+    </div>
+  );
+}

--- a/client/src/components/document/Document.jsx
+++ b/client/src/components/document/Document.jsx
@@ -6,6 +6,7 @@ import { UIContext } from '../../context/UIContext';
 import Editor from './Editor';
 import Preview from './Preview';
 import Sidebar from '@components/layout/Sidebar';
+import Delete from './Delete';
 import { getCookie } from '../../utils/cookies';
 import axios from 'axios';
 
@@ -19,7 +20,7 @@ export default function Document() {
     setIsDocumentUpdated,
   } = useContext(DocumentContext);
   const { setIsLoggedIn } = useContext(AuthContext);
-  const { displaySidebar } = useContext(UIContext);
+  const { displaySidebar, modal } = useContext(UIContext);
   const [loadingData, setLoadingData] = useState(false);
 
   useEffect(() => {
@@ -64,6 +65,12 @@ export default function Document() {
     }
   }, [id, isDocumentUpdated]);
 
+  const modalComponents = {
+    delete: Delete,
+  };
+
+  const ModalComponent = modalComponents[modal];
+
   return (
     <main>
       {loadingData ? (
@@ -77,6 +84,7 @@ export default function Document() {
         </section>
       )}
       {displaySidebar && <Sidebar />}
+      {ModalComponent && <ModalComponent />}
     </main>
   );
 }

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -21,7 +21,7 @@ export default function Navbar() {
   const { document, setDocument, setIsDocumentUpdated } =
     useContext(DocumentContext);
   const { isLoggedIn } = useContext(AuthContext);
-  const { setDisplaySidebar } = useContext(UIContext);
+  const { setDisplaySidebar, openModal } = useContext(UIContext);
 
   function handleInputChange(e) {
     setDocument(prevState => {
@@ -109,7 +109,10 @@ export default function Navbar() {
               onChange={handleInputChange}
             />
           </div>
-          <FontAwesomeIcon icon={faTrashCan} />
+          <FontAwesomeIcon
+            icon={faTrashCan}
+            onClick={() => openModal('delete')}
+          />
           <FontAwesomeIcon icon={faFloppyDisk} onClick={handleSaveDocument} />
           <FontAwesomeIcon icon={faUser} />{' '}
         </>

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import { UIContext } from '../../context/UIContext';
+
+export default function Modal({ children }) {
+  const { closeModal } = useContext(UIContext);
+
+  function handleModalClick(e) {
+    e.stopPropagation();
+  }
+
+  return (
+    <div onClick={closeModal}>
+      <div onClick={handleModalClick}>{children}</div>
+    </div>
+  );
+}

--- a/client/src/context/UIContext.jsx
+++ b/client/src/context/UIContext.jsx
@@ -4,9 +4,27 @@ const UIContext = createContext();
 
 function UIContextProvider(props) {
   const [displaySidebar, setDisplaySidebar] = useState(false);
+  const [modal, setModal] = useState(null);
+
+  function openModal(modalKey) {
+    setModal(modalKey);
+  }
+
+  function closeModal() {
+    setModal(null);
+  }
 
   return (
-    <UIContext.Provider value={{ displaySidebar, setDisplaySidebar }}>
+    <UIContext.Provider
+      value={{
+        displaySidebar,
+        setDisplaySidebar,
+        modal,
+        setModal,
+        openModal,
+        closeModal,
+      }}
+    >
       {props.children}
     </UIContext.Provider>
   );


### PR DESCRIPTION
## Description
This PR allows users to delete their markdown documents. I created the `Delete` modal which appears when the delete icon in the navbar is clicked, setting the `modal` state to `'delete'`. The modal displays a confirmation message asking if the user would like to delete the current document. Once the 'Confirm & Delete' button is clicked, a DELETE request is sent to `'/document/deleteDocument'` with the document id as a query parameter. On the server, it queries the database for the document based on the current user and the document id, deletes the document and then sends back a 204 status code. 

After successful deletion, I implemented the navigation logic for where users should be navigated based on the index of the deleted document. I used the `findIndex` method to calculate the index of the current document within the `allDocuments` array, storing it in `documentIndex`. If the document deleted is the only document in the array, I set the `document` state with the default markdown content and users are navigated back to the `/document` route, to view the default markdown content. If the first document in the array is deleted, users are navigated to the route of the next document in the array. For all other documents being deleted, users will be navigated to the document preceding the one being deleted.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |