### PR TITLE
Feat: Save Formatted Markdown as PDF

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "axios": "^1.7.2",
+        "html2pdf.js": "^0.10.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
@@ -336,6 +337,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1348,6 +1360,12 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
@@ -1631,6 +1649,17 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
@@ -1708,6 +1737,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1774,6 +1811,17 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -1830,6 +1878,31 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -1982,6 +2055,17 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/core-js": {
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1994,6 +2078,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2184,6 +2276,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dompurify": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.6.tgz",
+      "integrity": "sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==",
+      "optional": true
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2359,6 +2457,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2788,6 +2891,11 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -3222,6 +3330,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.2.tgz",
+      "integrity": "sha512-WyHVeMb18Bp7vYTmBv1GVsThH//K7SRfHdSdhHPkl4JvyQarNQXnailkYn0QUbRRmnN5rdbbmSIGEsPZtzPy2Q==",
+      "dependencies": {
+        "es6-promise": "^4.2.5",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^2.3.1"
       }
     },
     "node_modules/ignore": {
@@ -3821,6 +3951,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -4892,6 +5039,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -5171,6 +5324,15 @@
         }
       ]
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5305,6 +5467,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -5388,6 +5555,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -5615,6 +5791,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
       }
     },
     "node_modules/string-width": {
@@ -5905,6 +6090,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.6.tgz",
@@ -5957,6 +6151,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -6281,6 +6483,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "axios": "^1.7.2",
+    "html2pdf.js": "^0.10.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",

--- a/client/src/components/document/Document.jsx
+++ b/client/src/components/document/Document.jsx
@@ -103,6 +103,7 @@ export default function Document() {
             ) : (
               <Preview
                 markdown={document.content}
+                document={document}
                 setShowPreview={setShowPreview}
               />
             )}
@@ -120,6 +121,7 @@ export default function Document() {
             />
             <Preview
               markdown={document.content}
+              document={document}
               showPreview={showPreview}
               setShowPreview={setShowPreview}
             />

--- a/client/src/components/document/Editor.jsx
+++ b/client/src/components/document/Editor.jsx
@@ -49,7 +49,7 @@ export default function Editor({
         showPreview ? 'hidden' : 'md:w-1/2'
       } md:border-r-[1px] border-[#E4E4E4]`}
     >
-      <div className="text-[#7C8187] bg-[#F5F5F5] flex justify-between items-center py-3 px-3 -mx-4">
+      <div className="text-[#7C8187] bg-[#F5F5F5] flex justify-between items-center py-[14px] px-3 -mx-4">
         <span className="text-[14px] font-medium tracking-wider uppercase">
           Markdown
         </span>

--- a/client/src/components/document/Preview.jsx
+++ b/client/src/components/document/Preview.jsx
@@ -113,9 +113,7 @@ export default function Preview({
             ),
           }}
           className={`font-robotoSlab flex flex-col gap-5 py-4 ${
-            showPreview
-              ? 'md:py-6 md:px-12 lg:px-[384px]'
-              : 'md:py-[22px] md:px-2'
+            showPreview ? 'md:py-6 md:px-12 lg:px-96' : 'md:py-[22px] md:px-2'
           }`}
         >
           {markdown}

--- a/client/src/components/document/Preview.jsx
+++ b/client/src/components/document/Preview.jsx
@@ -39,7 +39,7 @@ export default function Preview({
         </span>
         <button
           onClick={downloadAsPDF}
-          className="flex items-center gap-2 border-[1px] rounded px-3 py-[1px]"
+          className="flex items-center gap-2 border-[1px] rounded px-3 py-[1px] hover:border-gray-600 hover:text-gray-600"
         >
           <FontAwesomeIcon icon={faFileArrowDown} />
           Save as PDF

--- a/client/src/components/document/Preview.jsx
+++ b/client/src/components/document/Preview.jsx
@@ -1,19 +1,49 @@
 import Markdown from 'react-markdown';
+import html2pdf from 'html2pdf.js';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEyeSlash, faEye } from '@fortawesome/free-solid-svg-icons';
+import {
+  faEyeSlash,
+  faEye,
+  faFileArrowDown,
+} from '@fortawesome/free-solid-svg-icons';
 
-export default function Preview({ markdown, showPreview, setShowPreview }) {
+export default function Preview({
+  markdown,
+  document,
+  showPreview,
+  setShowPreview,
+}) {
+  function downloadAsPDF() {
+    const element = window.document.getElementById('preview-content');
+    const opt = {
+      margin: [0, 0.5, 0.5, 0.5],
+      filename: `${document.name.slice(0, -3)}.pdf`,
+      image: { type: 'jpeg', quality: 0.98 },
+      html2canvas: { scale: 2 },
+      jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
+    };
+
+    html2pdf().set(opt).from(element).save();
+  }
+
   return (
     <section
       className={`w-screen h-screen flex flex-col px-4 ${
         showPreview ? 'w-screen' : 'md:w-1/2'
       }`}
     >
-      <div className="text-[#7C8187] bg-[#F5F5F5] flex justify-between items-center py-3 px-3 -mx-4">
-        <span className="text-[14px] font-medium tracking-wider uppercase">
+      <div className="text-[#7C8187] bg-[#F5F5F5] text-[14px] flex justify-between  gap-6 items-center py-3 px-3 -mx-4">
+        <span className="font-medium tracking-wider uppercase mr-auto">
           Preview
         </span>
+        <button
+          onClick={downloadAsPDF}
+          className="flex items-center gap-2 border-[1px] rounded px-3 py-[1px]"
+        >
+          <FontAwesomeIcon icon={faFileArrowDown} />
+          Save as PDF
+        </button>
         <FontAwesomeIcon
           icon={faEyeSlash}
           onClick={() => setShowPreview(false)}
@@ -25,70 +55,72 @@ export default function Preview({ markdown, showPreview, setShowPreview }) {
           className="hidden md:block hover:cursor-pointer"
         />
       </div>
-      <Markdown
-        components={{
-          h1: ({ node, ...props }) => (
-            <h1 className="text-blueGray text-[32px] font-bold" {...props} />
-          ),
-          h2: ({ node, ...props }) => (
-            <h2 className="text-blueGray text-[28px] font-light" {...props} />
-          ),
-          h3: ({ node, ...props }) => (
-            <h3 className="text-blueGray text-2xl font-bold" {...props} />
-          ),
-          h4: ({ node, ...props }) => (
-            <h4 className="text-blueGray text-xl font-bold" {...props} />
-          ),
-          h5: ({ node, ...props }) => (
-            <h5 className="text-blueGray text-base font-bold" {...props} />
-          ),
-          h6: ({ node, ...props }) => (
-            <h6 className="text-bloodOrange text-sm font-bold" {...props} />
-          ),
-          p: ({ node, ...props }) => (
-            <p className="text-bodyGray text-sm leading-6" {...props} />
-          ),
-          ol: ({ node, ...props }) => (
-            <ol
-              className="text-bodyGray text-sm leading-6 list-decimal pl-6 list-outside"
-              {...props}
-            />
-          ),
-          ul: ({ node, ...props }) => (
-            <ul
-              className="text-bodyGray text-sm leading-6 list-disc pl-6 list-outside"
-              {...props}
-            />
-          ),
-          li: ({ node, ...props }) => <li className="pl-2" {...props} />,
-          blockquote: ({ node, ...props }) => (
-            <blockquote
-              className="bg-[#F5F5F5] font-bold text-sm leading-6 rounded border-l-4 border-bloodOrange p-6"
-              {...props}
-            />
-          ),
-          a: ({ node, ...props }) => <a className="underline" {...props} />,
-          code: ({ node, ...props }) => (
-            <code
-              className="text-blueGray text-sm leading-6 w-full"
-              {...props}
-            />
-          ),
-          pre: ({ node, ...props }) => (
-            <pre
-              className="text-blueGray bg-[#F5F5F5] text-sm leading-6 rounded p-6 overflow-auto"
-              {...props}
-            />
-          ),
-        }}
-        className={`font-robotoSlab flex flex-col gap-5 py-4 ${
-          showPreview
-            ? 'md:py-6 md:px-12 lg:px-[384px]'
-            : 'md:py-[22px] md:px-2'
-        }`}
-      >
-        {markdown}
-      </Markdown>
+      <div id="preview-content">
+        <Markdown
+          components={{
+            h1: ({ node, ...props }) => (
+              <h1 className="text-blueGray text-[32px] font-bold" {...props} />
+            ),
+            h2: ({ node, ...props }) => (
+              <h2 className="text-blueGray text-[28px] font-light" {...props} />
+            ),
+            h3: ({ node, ...props }) => (
+              <h3 className="text-blueGray text-2xl font-bold" {...props} />
+            ),
+            h4: ({ node, ...props }) => (
+              <h4 className="text-blueGray text-xl font-bold" {...props} />
+            ),
+            h5: ({ node, ...props }) => (
+              <h5 className="text-blueGray text-base font-bold" {...props} />
+            ),
+            h6: ({ node, ...props }) => (
+              <h6 className="text-bloodOrange text-sm font-bold" {...props} />
+            ),
+            p: ({ node, ...props }) => (
+              <p className="text-bodyGray text-sm leading-6" {...props} />
+            ),
+            ol: ({ node, ...props }) => (
+              <ol
+                className="text-bodyGray text-sm leading-6 list-decimal pl-6 list-outside"
+                {...props}
+              />
+            ),
+            ul: ({ node, ...props }) => (
+              <ul
+                className="text-bodyGray text-sm leading-6 list-disc pl-6 list-outside"
+                {...props}
+              />
+            ),
+            li: ({ node, ...props }) => <li className="pl-2" {...props} />,
+            blockquote: ({ node, ...props }) => (
+              <blockquote
+                className="bg-[#F5F5F5] font-bold text-sm leading-6 rounded border-l-4 border-bloodOrange p-6"
+                {...props}
+              />
+            ),
+            a: ({ node, ...props }) => <a className="underline" {...props} />,
+            code: ({ node, ...props }) => (
+              <code
+                className="text-blueGray text-sm leading-6 w-full"
+                {...props}
+              />
+            ),
+            pre: ({ node, ...props }) => (
+              <pre
+                className="text-blueGray bg-[#F5F5F5] text-sm leading-6 rounded p-6 overflow-auto"
+                {...props}
+              />
+            ),
+          }}
+          className={`font-robotoSlab flex flex-col gap-5 py-4 ${
+            showPreview
+              ? 'md:py-6 md:px-12 lg:px-[384px]'
+              : 'md:py-[22px] md:px-2'
+          }`}
+        >
+          {markdown}
+        </Markdown>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Description
This PR adds the functionality allowing users to save their formatted Markdown content as a PDF. It utilizes the html2pdf library, which leverages html2canvas and jsPDF to convert HTML elements into a downloadable PDF format. I created a "Save As PDF" button in the Preview component. This button fires off the `downloadAsPDF` function which handles the PDF conversion process. It selects the `div` with the ID `preview-content`, which contains the rendered Markdown content.
I then configured it with various PDF options such as margins, filename, image quality, canvas scale, and PDF format to ensure it is formatted correctly. It then calls the `html2pdf` function passing in the selected HTML element and configuration options and converts the HTML content into a PDF and automatically downloads the file.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |